### PR TITLE
Refactor out special cases with indirect pointer

### DIFF
--- a/linked_list/cpp/test/ut_linked_list.hpp
+++ b/linked_list/cpp/test/ut_linked_list.hpp
@@ -214,7 +214,10 @@ TEST_F(LinkedListTest, Remove) {
 
   auto* tar = list_.Find(EqualTo(VALUE_TO_REMOVE));
   ASSERT_TRUE(tar);
+
   list_.Remove(tar);
+  delete tar;
+  tar = nullptr;
 
   int i = 0;
   for (const Node<int>* cur = list_.head(); cur; cur = cur->next) {
@@ -235,7 +238,12 @@ TEST_F(LinkedListTest, RemoveHead) {
   for (int i = 0; i < 10; ++i) {
     list_.AppendBack(i);
   }
-  list_.Remove(list_.Find(EqualTo(0 /* this is the head */)));
+  Node<int>* head = list_.Find(EqualTo(0));
+
+  list_.Remove(head);
+  delete head;
+  head = nullptr;
+
   ASSERT_TRUE(list_.head());
   ASSERT_EQ(1, list_.head()->value);
   ASSERT_EQ(2, list_.head()->next->value);
@@ -249,7 +257,11 @@ TEST_F(LinkedListTest, RemoveTail) {
   for (int i = 0; i < 10; ++i) {
     list_.AppendBack(i);
   }
-  list_.Remove(list_.Find(EqualTo(9 /* this is the tail */)));
+  Node<int>* tail = list_.Find(EqualTo(9));
+
+  list_.Remove(tail);
+  delete tail;
+  tail = nullptr;
 
   ASSERT_TRUE(list_.tail());
   ASSERT_EQ(8, list_.tail()->value);
@@ -268,7 +280,12 @@ TEST_F(LinkedListTest, RemoveTail) {
  */
 TEST_F(LinkedListTest, RemoveLastOne) {
   list_.AppendFront(1);
-  list_.Remove(list_.Find(EqualTo(1)));
+  Node<int>* last = list_.Find(EqualTo(1));
+
+  list_.Remove(last);
+  delete last;
+  last = nullptr;
+
   ASSERT_TRUE(list_.IsEmpty());
 }
 
@@ -280,8 +297,7 @@ TEST_F(LinkedListTest, RemoveNotExists) {
     list_.AppendBack(i);
   }
   auto tar = Node<int>{50};
-  /* "invalid pointer" will occur immediately if this
-    stack-allocated pointer is deleted */
+
   list_.Remove(&tar);
 
   /* tar not modified */
@@ -307,4 +323,42 @@ TEST_F(LinkedListTest, IsEmpty) {
 
   list_.Remove(list_.Find(EqualTo(0)));
   ASSERT_TRUE(list_.IsEmpty());
+}
+
+/**
+ * @brief An empty list shouldn't be broken after the reversal.
+ */
+TEST_F(LinkedListTest, ReverseEmpty) {
+  list_.Reverse();
+  ASSERT_TRUE(list_.IsEmpty());
+}
+
+/**
+ * @brief A list with only 1 node should stay the same after the reversal.
+ */
+TEST_F(LinkedListTest, ReverseOnlyOne) {
+  list_.AppendFront(1);
+  ASSERT_TRUE(list_.head());
+  ASSERT_TRUE(list_.tail());
+  ASSERT_TRUE(list_.head() == list_.tail());
+  ASSERT_EQ(1, list_.head()->value);
+  ASSERT_FALSE(list_.head()->next);
+}
+
+/**
+ * @brief Normally reverse a list with 100 nodes.
+ */
+TEST_F(LinkedListTest, Reverse) {
+  for (int i = 0; i < 100; ++i) {
+    list_.AppendBack(i);
+  }
+
+  list_.Reverse();
+
+  int i = 99;
+  for (const Node<int>* cur = list_.head(); cur; cur = cur->next) {
+    ASSERT_EQ(i--, cur->value);
+  }
+  ASSERT_EQ(-1, i);
+  ASSERT_FALSE(list_.tail()->next);  /* all links should be reversed */
 }


### PR DESCRIPTION
- Special cases are made normal in `Remove()`.
- `Remove()` no longer deletes the *tar* pointer since this operation is considered as taking the node out of the list.
Further operations can be made on the node; the caller is responsible for handling its life time.

- [x] unit test passed

Resolves: #1 