### PR TITLE
Skip list

### DIFF
--- a/skip_list/README.md
+++ b/skip_list/README.md
@@ -1,1 +1,17 @@
 # Skip List
+
+Skip lists are data structures that use probabilistic balancing rather than strictly enforced balancing. \
+As a result, the algorithms for insertion and deletion in skip lists are much simpler and significantly faster than equivalent algorithms for balanced trees.
+
+## Complexity
+
+|Operation       |Average    |Worst case    |
+|----------------|-----------|--------------|
+|Space           |O(*n*)     |O(*n\*lg(n)*) |
+|Find            |O(*lg(n)*) |O(*n*)        |
+|Insert (Update) |O(*lg(n)*) |O(*n*)        |
+|Delete          |O(*lg(n)*) |O(*n*)        |
+
+## Reference
+
+- PUGH, William. Skip lists: a probabilistic alternative to balanced trees. Communications of the ACM, 1990, 33.6: 668-676.

--- a/skip_list/src/debug.hpp
+++ b/skip_list/src/debug.hpp
@@ -1,9 +1,8 @@
 #ifndef SRC_DEBUG_HPP_
 #define SRC_DEBUG_HPP_
 
-#include <cstdio>
+#include <iostream>
 #include <cstdlib>
-
 
 #ifdef ENABLE_DEBUG
   #define ASSERT(condition) \
@@ -14,6 +13,5 @@
 #else
   #define ASSERT(condition) ; /* replace with a single semi-colon */
 #endif
-
 
 #endif /* end of include guard: SRC_DEBUG_HPP_ */

--- a/skip_list/src/debug.hpp
+++ b/skip_list/src/debug.hpp
@@ -1,0 +1,19 @@
+#ifndef SRC_DEBUG_HPP_
+#define SRC_DEBUG_HPP_
+
+#include <cstdio>
+#include <cstdlib>
+
+
+#ifdef ENABLE_DEBUG
+  #define ASSERT(condition) \
+    if (!(condition)) {  \
+      std::cerr << "Assertion failed: line " << __LINE__ << " file " << __FILE__ << '\n';  \
+      std::abort();  \
+    }
+#else
+  #define ASSERT(condition) ; /* replace with a single semi-colon */
+#endif
+
+
+#endif /* end of include guard: SRC_DEBUG_HPP_ */

--- a/skip_list/src/debug.hpp
+++ b/skip_list/src/debug.hpp
@@ -1,8 +1,8 @@
 #ifndef SRC_DEBUG_HPP_
 #define SRC_DEBUG_HPP_
 
-#include <iostream>
 #include <cstdlib>
+#include <iostream>
 
 /**
  * Define `ASSERT_DEBUG` before including this file to enable the assertion feature.

--- a/skip_list/src/debug.hpp
+++ b/skip_list/src/debug.hpp
@@ -4,14 +4,18 @@
 #include <iostream>
 #include <cstdlib>
 
-#ifdef ENABLE_DEBUG
+/**
+ * Define `ASSERT_DEBUG` before including this file to enable the assertion feature.
+ */
+#ifdef ASSERT_DEBUG
   #define ASSERT(condition) \
     if (!(condition)) {  \
       std::cerr << "Assertion failed: line " << __LINE__ << " file " << __FILE__ << '\n';  \
       std::abort();  \
     }
 #else
-  #define ASSERT(condition) ; /* replace with a single semi-colon */
+  /* replace with "nothing" to disable the assertion */
+  #define ASSERT(condition)
 #endif
 
 #endif /* end of include guard: SRC_DEBUG_HPP_ */

--- a/skip_list/src/skip_list.hpp
+++ b/skip_list/src/skip_list.hpp
@@ -20,7 +20,7 @@
  *
  * Implements the following operations:
  *  - SkipNode<K, V>* Find(const K& key) const
- *  - void Insert(const std::pair<K, V>& key_value_pair)
+ *  - void Insert(const KeyValuePair<K, V>& key_value_pair)
  *  - void Delete(const K& key)
  *
  * @note I could have use smart pointer and containers to make the resource

--- a/skip_list/src/skip_list.hpp
+++ b/skip_list/src/skip_list.hpp
@@ -1,21 +1,57 @@
 #ifndef SRC_SKIP_LIST_HPP_
 #define SRC_SKIP_LIST_HPP_
 
+#define ENABLE_DEBUG 1  /* enable debug macros */
+
+#include "debug.hpp"
 #include "skip_node.hpp"
 
 
 template<typename T>
 class SkipList {
 public:
-  constexpr double LEVEL_UP_PROB = 0.5;
-  constexpr int MAX_LEVEL = 16;
+  /**
+   * @brief The probability that an inserted node be promoted.
+   * 50 percent are level 1, 25 percent are level 2,
+   * 12.5 percent are level 3 and so on.
+   */
+  static constexpr double LEVEL_UP_PROB = 0.5;
 
-  SkipNode<T>* Find(const T& value) const;
+  /// The highest possible level.
+  static constexpr int MAX_LEVEL = 16;
+
+  /// Returns the node with `value` if found, otherwise nullptr.
+  SkipNode<T>* Find(const T& value) const {
+    const SkipNode<T>* cur = head_;
+
+    /* from top to down */
+    for (int i = level_count_; i > 0; --i) {
+      /* from left to right */
+      while (cur->forward(i) && cur->forward(i) < value) {
+        cur = cur->forward(i);
+      }
+    }
+    cur = cur->forward(1);
+
+    ASSERT(!cur || cur->value() >= value);
+
+    /*
+     * We're now down to the 1st level with cur->value >= `value`,
+     * so if cur->value is not equal to `value`, node with `value`
+     * doesn't exist.
+     */
+    if (!cur || cur->value() != value) {
+      return nullptr;
+    }
+    return const_cast<SkipNode<T>*>(cur);
+  }
+
   void Insert(const T& value);
   void Delete(const T& value);
 
 private:
-
+  SkipNode<T>* head_ = new SkipNode<T>(T{/* default dummy value */}, MAX_LEVEL);
+  int level_count_ = 1;  /* level starts from 1. */
 };
 
 

--- a/skip_list/src/skip_node.hpp
+++ b/skip_list/src/skip_node.hpp
@@ -36,14 +36,14 @@ public:
     if (level > level_) {
       throw LevelRelationException("level " + std::to_string(level) + " exceeds the limit, which is " + std::to_string(level_));
     }
-    if (forward->level() < level) {
+    if (forward /* no check if is null */ && forward->level() < level) {
       throw LevelRelationException("a level " + std::to_string(level) + " forward node should have its level greater than "
                                    + std::to_string(level) + ", but only " + std::to_string(forward->level()));
     }
     forwards_[level - 1] = forward;
   }
 
-  SkipNode<T>* forward(const int level) {
+  SkipNode<T>* forward(const int level) const {
     if (level > level_) {
       throw LevelRelationException("level " + std::to_string(level) + " exceeds the limit, which is " + std::to_string(level_));
     }

--- a/skip_list/src/skip_node.hpp
+++ b/skip_list/src/skip_node.hpp
@@ -1,6 +1,13 @@
 #ifndef SRC_SKIP_NODE_HPP_
 #define SRC_SKIP_NODE_HPP_
 
+
+/**
+ * Define `MEM_DEBUG` before including this file to enable the memory
+ * allocation-deallocation counting feature, which can be used to test memory leaks.
+ */
+
+
 #include <exception>
 #include <string>
 
@@ -17,11 +24,26 @@ public:
   /// A SkipNode has a value and knows its level.
   SkipNode(const T& value, const int level)
       : value_{value}, level_{level}, forwards_{new SkipNode<T>*[level]} {
-    /* forward nodes are automatically initialized to nullptr */
+    /* initialize forward nodes to nullptr */
+    for (int i = 0; i < level; ++i) {
+      forwards_[i] = nullptr;
+    }
+#ifdef MEM_DEBUG
+    ++alloc_count;
+#endif
   }
 
+#ifdef MEM_DEBUG
+  static int alloc_count;
+  static int dealloc_count;
+#endif
+
   ~SkipNode() {
+    /* only delete the forward containing array, not the nodes linked to */
     delete [] forwards_;
+#ifdef MEM_DEBUG
+    ++dealloc_count;
+#endif
   }
 
   T value() const {
@@ -57,5 +79,12 @@ private:
   SkipNode<T>** forwards_;
 };
 
+#ifdef MEM_DEBUG
+template<typename T>
+int SkipNode<T>::alloc_count = 0;
+
+template<typename T>
+int SkipNode<T>::dealloc_count = 0;
+#endif
 
 #endif /* end of include guard: SRC_SKIP_NODE_HPP_ */

--- a/skip_list/src/skip_node.hpp
+++ b/skip_list/src/skip_node.hpp
@@ -1,7 +1,6 @@
 #ifndef SRC_SKIP_NODE_HPP_
 #define SRC_SKIP_NODE_HPP_
 
-
 /**
  * Define `MEM_DEBUG` before including this file to enable the memory
  * allocation-deallocation counting feature, which can be used to test memory leaks.
@@ -12,6 +11,7 @@
 #include <string>
 
 
+/// Indicates that there's something wrong about the relation between a node and its forward node.
 class LevelRelationException : public std::runtime_error {
   using std::runtime_error::runtime_error;  /* use base class constructors */
 };
@@ -21,7 +21,7 @@ class LevelRelationException : public std::runtime_error {
 template<typename T>
 class SkipNode {
 public:
-  /// A SkipNode has a value and knows its level.
+  /// A SkipNode has a `value` and knows its `level`.
   SkipNode(const T& value, const int level)
       : value_{value}, level_{level}, forwards_{new SkipNode<T>*[level]} {
     /* initialize forward nodes to nullptr */
@@ -34,6 +34,7 @@ public:
   }
 
 #ifdef MEM_DEBUG
+  /// count the number of alloc-deallocations
   static int alloc_count;
   static int dealloc_count;
 #endif
@@ -54,6 +55,11 @@ public:
     return level_;
   }
 
+  /**
+   * @throw LevelRelationException:
+   *  (1) set to a non-existing level
+   *  (2) set a low level node as a high level forward node
+   */
   void set_forward(SkipNode<T>* const forward, const int level) {
     if (level > level_) {
       throw LevelRelationException("level " + std::to_string(level) + " exceeds the limit, which is " + std::to_string(level_));
@@ -65,6 +71,9 @@ public:
     forwards_[level - 1] = forward;
   }
 
+  /**
+   * @throw LevelRelationException: get from a non-existing level
+   */
   SkipNode<T>* forward(const int level) const {
     if (level > level_) {
       throw LevelRelationException("level " + std::to_string(level) + " exceeds the limit, which is " + std::to_string(level_));

--- a/skip_list/test/ut_main.cpp
+++ b/skip_list/test/ut_main.cpp
@@ -1,3 +1,7 @@
+#ifndef MEM_DEBUG
+  #define MEM_DEBUG
+#endif
+
 #include "ut_skip_node.hpp"
 #include "ut_skip_list.hpp"
 

--- a/skip_list/test/ut_main.cpp
+++ b/skip_list/test/ut_main.cpp
@@ -1,4 +1,5 @@
 #include "ut_skip_node.hpp"
+#include "ut_skip_list.hpp"
 
 #include <gtest/gtest.h>
 

--- a/skip_list/test/ut_skip_list.hpp
+++ b/skip_list/test/ut_skip_list.hpp
@@ -1,68 +1,80 @@
 #include <gtest/gtest.h>
+#include <string>
 
 #include "../src/skip_list.hpp"
 #include "../src/skip_node.hpp"
 
 
-/// The first value of the list should be inserted without any exception thrown.
-TEST(SkipListTest, InsertFirstNode) {
-  SkipList<int> list{};
+class SkipListTest : public ::testing::Test {
+protected:
+  SkipList<int, std::string> list_ = SkipList<int, std::string>{};
+};
 
-  ASSERT_NO_THROW(list.Insert(1));
+
+/// The first value of the list should be inserted without any exception thrown.
+TEST_F(SkipListTest, InsertFirstNode) {
+  ASSERT_NO_THROW(list_.Insert({1, "1"}));
 }
 
 
 /// Inserts 10 numbers, all of them should be inserted without any exceptions thrown.
-TEST(SkipListTest, InsertNumberOneToTen) {
-  SkipList<int> list{};
-
+TEST_F(SkipListTest, InsertNumberOneToTen) {
   ASSERT_NO_THROW({
     for (int i = 1; i <= 10; ++i) {
-      list.Insert(i);
+      list_.Insert({i, std::to_string(i)});
     }
   });
 }
 
 
 /// Though dummy value "0" is used in SkipList<int>, `value` insertion shouldn't be affected.
-TEST(SkipListTest, InsertNumberNegativeTenToPositiveTen) {
-  SkipList<int> list{};
+TEST_F(SkipListTest, InsertNumberNegativeTenToPositiveTen) {
+  ASSERT_NO_THROW({
+    for (int i = -10; i <= 10; ++i) {
+      list_.Insert({i, std::to_string(i)});
+    }
+  });
+}
+
+
+/// Existing keys should be inserted without any exceptions thrown.
+TEST_F(SkipListTest, InsertExistingKey) {
+  for (int i = -10; i <= 10; ++i) {
+    list_.Insert({i, std::to_string(i)});
+  }
 
   ASSERT_NO_THROW({
     for (int i = -10; i <= 10; ++i) {
-      list.Insert(i);
+      list_.Insert({i, std::to_string(i)});
     }
   });
 }
 
 
 /// Finds from an empty list, should get a null pointer.
-TEST(SkipListTest, FindEmptyList) {
-  SkipList<int> list{};
-
-  auto* node = list.Find(-100);
+TEST_F(SkipListTest, FindEmptyList) {
+  auto* node = list_.Find(-100);
 
   ASSERT_TRUE(node == nullptr);
 }
 
 
 /// Finds value from a one value list.
-TEST(SkipListTest, FindOnlyValueInList) {
-  SkipList<int> list{};
-  list.Insert(1);
+TEST_F(SkipListTest, FindOnlyValueInList) {
+  list_.Insert({1, "1"});
 
-  auto* node = list.Find(1);
+  auto* node = list_.Find(1);
 
   ASSERT_TRUE(node != nullptr);
-  ASSERT_EQ(1, node->value());
+  ASSERT_EQ(1, node->key());
+  ASSERT_EQ("1", node->value());
 }
 
 
 /// Inserts 50 values and finds all of them one by one.
-TEST(SkipListTest, FindValues) {
-  SkipList<int> list{};
+TEST_F(SkipListTest, FindValues) {
   for (int i = 1; i <= 50; ++i) {
-    list.Insert(i);
+    list_.Insert({i, std::to_string(i)});
   }
 
   const int order[] = {  /* a random generated order */
@@ -71,50 +83,71 @@ TEST(SkipListTest, FindValues) {
     19, 41, 16, 9, 14, 25, 18, 11, 21, 46, 4,
   };
   for (const int i : order) {
-    auto* node = list.Find(i);
+    auto* node = list_.Find(i);
 
     ASSERT_TRUE(node != nullptr);
-    ASSERT_EQ(i, node->value());
+    ASSERT_EQ(i, node->key());
+    ASSERT_EQ(std::to_string(i), node->value());
   }
 }
 
 
 /// Though dummy value "0" is used in SkipList<int>, `value` find shouldn't be affected.
-TEST(SkipListTest, FindValuesNegativeTenToPositiveTen) {
-  SkipList<int> list{};
-
+TEST_F(SkipListTest, FindValuesNegativeTenToPositiveTen) {
   for (int i = -10; i <= 10; ++i) {
-    list.Insert(i);
+    list_.Insert({i, std::to_string(i)});
   }
 
   const int order[] = {  /* a random generated order */
     -10, 7, -9, -1, 3, 6, 0, 10, 1, -2, -6, 8, -4, 2, -3, 4, -5, 9, -7, -8, 5,
   };
   for (const int i : order) {
-    auto* node = list.Find(i);
+    auto* node = list_.Find(i);
 
     ASSERT_TRUE(node != nullptr);
-    ASSERT_EQ(i, node->value());
+    ASSERT_EQ(i, node->key());
+    ASSERT_EQ(std::to_string(i), node->value());
+  }
+}
+
+
+/// Inserting existing `key` should update the `value` of that `key`.
+TEST_F(SkipListTest, InsertExistingKeysToUpdateValues) {
+  for (int i = -10; i <= 10; ++i) {
+    list_.Insert({i, std::to_string(i)});
+  }
+
+  const int order[] = {  /* a random generated order */
+    -10, 7, -9, -1, 3, 6, 0, 10, 1, -2, -6, 8, -4, 2, -3, 4, -5, 9, -7, -8, 5,
+  };
+  for (const int i : order) {
+    list_.Insert({i, std::to_string(i + 100) /* new value */});
+  }
+
+  for (int i = -10; i <= 10; ++i) {
+    auto* node = list_.Find(i);
+
+    ASSERT_TRUE(node != nullptr);
+    ASSERT_EQ(i, node->key());
+    ASSERT_EQ(std::to_string(i + 100), node->value());
   }
 }
 
 
 /// The last value in the list should be deleted properly.
-TEST(SkipListTest, DeleteOnlyValueInList) {
-  SkipList<int> list{};
-  list.Insert(1);
+TEST_F(SkipListTest, DeleteOnlyValueInList) {
+  list_.Insert({1, "1"});
 
-  ASSERT_NO_THROW(list.Delete(1));
-  ASSERT_TRUE(list.Find(1) == nullptr);
+  ASSERT_NO_THROW(list_.Delete(1));
+  ASSERT_TRUE(list_.Find(1) == nullptr);
 }
 
 
 /// Deletes all 50 values from the list, so we should get nullptrs when we try to find those values.
-TEST(SkipListTest, DeleteValues) {
-  SkipList<int> list{};
+TEST_F(SkipListTest, DeleteValues) {
   /* insert values */
   for (int i = 1; i <= 50; ++i) {
-    list.Insert(i);
+    list_.Insert({i, std::to_string(i)});
   }
 
   /* delete all */
@@ -125,23 +158,21 @@ TEST(SkipListTest, DeleteValues) {
   };
   ASSERT_NO_THROW({
     for (const int i : order) {
-      list.Delete(i);
+      list_.Delete(i);
     }
   });
 
   /* find all */
   for (int i = 1; i <= 50; ++i) {
-    ASSERT_TRUE(list.Find(i) == nullptr);
+    ASSERT_TRUE(list_.Find(i) == nullptr);
   }
 }
 
 
 /// Though dummy value "0" is used in SkipList<int>, `value` deletion shouldn't be affected.
-TEST(SkipListTest, DeleteValuesNegativeTenToPositiveTen) {
-  SkipList<int> list{};
-
+TEST_F(SkipListTest, DeleteValuesNegativeTenToPositiveTen) {
   for (int i = -10; i <= 10; ++i) {
-    list.Insert(i);
+    list_.Insert({i, std::to_string(i)});
   }
 
   const int order[] = {  /* a random generated order */
@@ -149,57 +180,55 @@ TEST(SkipListTest, DeleteValuesNegativeTenToPositiveTen) {
   };
   ASSERT_NO_THROW({
     for (const int i : order) {
-      list.Delete(i);
+      list_.Delete(i);
     }
   });
 
   for (int i = -10; i <= 10; ++i) {
-    ASSERT_TRUE(list.Find(i) == nullptr);
+    ASSERT_TRUE(list_.Find(i) == nullptr);
   }
 }
 
 
 /// Deletion should clean up and re-link nodes properly so the coming insertion isn't broken.
-TEST(SkipListTest, InsertAndDeleteAlternately) {
-  SkipList<int> list{};
-
+TEST_F(SkipListTest, InsertAndDeleteAlternately) {
   for (int i = 0; i < 10; ++i) {
     for (int i = -10; i <= 10; ++i) {
-      list.Insert(i);
+      list_.Insert({i, std::to_string(i)});
     }
     for (int i = -10; i <= 10; ++i) {
-      auto* node = list.Find(i);
+      auto* node = list_.Find(i);
       ASSERT_TRUE(node != nullptr);
-      ASSERT_EQ(i, node->value());
+      ASSERT_EQ(i, node->key());
+      ASSERT_EQ(std::to_string(i), node->value());
     }
     for (int i = -10; i <= 10; ++i) {
-      list.Delete(i);
+      list_.Delete(i);
     }
     for (int i = -10; i <= 10; ++i) {
-      ASSERT_TRUE(list.Find(i) == nullptr);
+      ASSERT_TRUE(list_.Find(i) == nullptr);
     }
   }
 }
 
-
 #ifdef MEM_DEBUG
 
 /// The number of allocation and deallocation count should match, otherwise memory leaks.
-TEST(SkipListTest, DeallocateNodesProperly) {
+TEST_F(SkipListTest, DeallocateNodesProperly) {
   /* reset the counters */
-  SkipNode<int>::alloc_count = 0;
-  SkipNode<int>::dealloc_count = 0;
+  SkipNode<int, std::string>::alloc_count = 0;
+  SkipNode<int, std::string>::dealloc_count = 0;
 
   /* both counts should be 50 + 1 (header) after exiting the block */
   {
-    SkipList<int> list{};
+    SkipList<int, std::string> list{};
     for (int i = 1; i <= 50; ++i) {
-      list.Insert(i);
+      list.Insert({i, std::to_string(i)});
     }
   }
 
-  ASSERT_EQ(51, SkipNode<int>::alloc_count);
-  ASSERT_EQ(51, SkipNode<int>::dealloc_count);
+  ASSERT_EQ(51, (SkipNode<int, std::string>::alloc_count) /* the brackets are necessary to not break the macro */);
+  ASSERT_EQ(51, (SkipNode<int, std::string>::dealloc_count));
 }
 
 #endif

--- a/skip_list/test/ut_skip_list.hpp
+++ b/skip_list/test/ut_skip_list.hpp
@@ -79,6 +79,26 @@ TEST(SkipListTest, FindValues) {
 }
 
 
+/// Though dummy value "0" is used in SkipList<int>, `value` find shouldn't be affected.
+TEST(SkipListTest, FindValuesNegativeTenToPositiveTen) {
+  SkipList<int> list{};
+
+  for (int i = -10; i <= 10; ++i) {
+    list.Insert(i);
+  }
+
+  const int order[] = {  /* a random generated order */
+    -10, 7, -9, -1, 3, 6, 0, 10, 1, -2, -6, 8, -4, 2, -3, 4, -5, 9, -7, -8, 5,
+  };
+  for (const int i : order) {
+    auto* node = list.Find(i);
+
+    ASSERT_TRUE(node != nullptr);
+    ASSERT_EQ(i, node->value());
+  }
+}
+
+
 /// The last value in the list should be deleted properly.
 TEST(SkipListTest, DeleteOnlyValueInList) {
   SkipList<int> list{};
@@ -114,3 +134,72 @@ TEST(SkipListTest, DeleteValues) {
     ASSERT_TRUE(list.Find(i) == nullptr);
   }
 }
+
+
+/// Though dummy value "0" is used in SkipList<int>, `value` deletion shouldn't be affected.
+TEST(SkipListTest, DeleteValuesNegativeTenToPositiveTen) {
+  SkipList<int> list{};
+
+  for (int i = -10; i <= 10; ++i) {
+    list.Insert(i);
+  }
+
+  const int order[] = {  /* a random generated order */
+    -10, 7, -9, -1, 3, 6, 0, 10, 1, -2, -6, 8, -4, 2, -3, 4, -5, 9, -7, -8, 5,
+  };
+  ASSERT_NO_THROW({
+    for (const int i : order) {
+      list.Delete(i);
+    }
+  });
+
+  for (int i = -10; i <= 10; ++i) {
+    ASSERT_TRUE(list.Find(i) == nullptr);
+  }
+}
+
+
+/// Deletion should clean up and re-link nodes properly so the coming insertion isn't broken.
+TEST(SkipListTest, InsertAndDeleteAlternately) {
+  SkipList<int> list{};
+
+  for (int i = 0; i < 10; ++i) {
+    for (int i = -10; i <= 10; ++i) {
+      list.Insert(i);
+    }
+    for (int i = -10; i <= 10; ++i) {
+      auto* node = list.Find(i);
+      ASSERT_TRUE(node != nullptr);
+      ASSERT_EQ(i, node->value());
+    }
+    for (int i = -10; i <= 10; ++i) {
+      list.Delete(i);
+    }
+    for (int i = -10; i <= 10; ++i) {
+      ASSERT_TRUE(list.Find(i) == nullptr);
+    }
+  }
+}
+
+
+#ifdef MEM_DEBUG
+
+/// The number of allocation and deallocation count should match, otherwise memory leaks.
+TEST(SkipListTest, DeallocateNodesProperly) {
+  /* reset the counters */
+  SkipNode<int>::alloc_count = 0;
+  SkipNode<int>::dealloc_count = 0;
+
+  /* both counts should be 50 + 1 (header) after exiting the block */
+  {
+    SkipList<int> list{};
+    for (int i = 1; i <= 50; ++i) {
+      list.Insert(i);
+    }
+  }
+
+  ASSERT_EQ(51, SkipNode<int>::alloc_count);
+  ASSERT_EQ(51, SkipNode<int>::dealloc_count);
+}
+
+#endif

--- a/skip_list/test/ut_skip_list.hpp
+++ b/skip_list/test/ut_skip_list.hpp
@@ -77,3 +77,40 @@ TEST(SkipListTest, FindValues) {
     ASSERT_EQ(i, node->value());
   }
 }
+
+
+/// The last value in the list should be deleted properly.
+TEST(SkipListTest, DeleteOnlyValueInList) {
+  SkipList<int> list{};
+  list.Insert(1);
+
+  ASSERT_NO_THROW(list.Delete(1));
+  ASSERT_TRUE(list.Find(1) == nullptr);
+}
+
+
+/// Deletes all 50 values from the list, so we should get nullptrs when we try to find those values.
+TEST(SkipListTest, DeleteValues) {
+  SkipList<int> list{};
+  /* insert values */
+  for (int i = 1; i <= 50; ++i) {
+    list.Insert(i);
+  }
+
+  /* delete all */
+  const int order[] = {  /* a random generated order */
+    47, 42, 39, 12, 24, 23, 17, 7, 40, 33, 1, 3, 15, 2, 30, 34, 26, 44, 5, 36,
+    20, 22, 10, 29, 50, 6, 38, 37, 31, 32, 8, 49, 27, 28, 48, 43, 13, 35, 45,
+    19, 41, 16, 9, 14, 25, 18, 11, 21, 46, 4,
+  };
+  ASSERT_NO_THROW({
+    for (const int i : order) {
+      list.Delete(i);
+    }
+  });
+
+  /* find all */
+  for (int i = 1; i <= 50; ++i) {
+    ASSERT_TRUE(list.Find(i) == nullptr);
+  }
+}

--- a/skip_list/test/ut_skip_list.hpp
+++ b/skip_list/test/ut_skip_list.hpp
@@ -1,6 +1,79 @@
 #include <gtest/gtest.h>
 
 #include "../src/skip_list.hpp"
+#include "../src/skip_node.hpp"
 
 
-// TEST(SkipListTest, )
+/// The first value of the list should be inserted without any exception thrown.
+TEST(SkipListTest, InsertFirstNode) {
+  SkipList<int> list{};
+
+  ASSERT_NO_THROW(list.Insert(1));
+}
+
+
+/// Inserts 10 numbers, all of them should be inserted without any exceptions thrown.
+TEST(SkipListTest, InsertNumberOneToTen) {
+  SkipList<int> list{};
+
+  ASSERT_NO_THROW({
+    for (int i = 1; i <= 10; ++i) {
+      list.Insert(i);
+    }
+  });
+}
+
+
+/// Though dummy value "0" is used in SkipList<int>, `value` insertion shouldn't be affected.
+TEST(SkipListTest, InsertNumberNegativeTenToPositiveTen) {
+  SkipList<int> list{};
+
+  ASSERT_NO_THROW({
+    for (int i = -10; i <= 10; ++i) {
+      list.Insert(i);
+    }
+  });
+}
+
+
+/// Finds from an empty list, should get a null pointer.
+TEST(SkipListTest, FindEmptyList) {
+  SkipList<int> list{};
+
+  auto* node = list.Find(-100);
+
+  ASSERT_TRUE(node == nullptr);
+}
+
+
+/// Finds value from a one value list.
+TEST(SkipListTest, FindOnlyValueInList) {
+  SkipList<int> list{};
+  list.Insert(1);
+
+  auto* node = list.Find(1);
+
+  ASSERT_TRUE(node != nullptr);
+  ASSERT_EQ(1, node->value());
+}
+
+
+/// Inserts 50 values and finds all of them one by one.
+TEST(SkipListTest, FindValues) {
+  SkipList<int> list{};
+  for (int i = 1; i <= 50; ++i) {
+    list.Insert(i);
+  }
+
+  const int order[] = {  /* a random generated order */
+    47, 42, 39, 12, 24, 23, 17, 7, 40, 33, 1, 3, 15, 2, 30, 34, 26, 44, 5, 36,
+    20, 22, 10, 29, 50, 6, 38, 37, 31, 32, 8, 49, 27, 28, 48, 43, 13, 35, 45,
+    19, 41, 16, 9, 14, 25, 18, 11, 21, 46, 4,
+  };
+  for (const int i : order) {
+    auto* node = list.Find(i);
+
+    ASSERT_TRUE(node != nullptr);
+    ASSERT_EQ(i, node->value());
+  }
+}

--- a/skip_list/test/ut_skip_list.hpp
+++ b/skip_list/test/ut_skip_list.hpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+#include "../src/skip_list.hpp"
+
+
+// TEST(SkipListTest, )

--- a/skip_list/test/ut_skip_node.hpp
+++ b/skip_list/test/ut_skip_node.hpp
@@ -19,6 +19,15 @@ TEST(SkipNodeTest, CallConstructor) {
 }
 
 
+/// The forward nodes can be null.
+TEST(SkipNodeTest, SetForwardNull) {
+  SkipNode<std::string> node{"MyNode", 5};
+
+  ASSERT_NO_THROW(node.set_forward(nullptr, 1));
+  ASSERT_TRUE(node.forward(1) == nullptr);
+}
+
+
 /// Forward nodes should be properly set and get when they don't exceed the forward level that the node can have.
 TEST(SkipNodeTest, SetForwardInLimit) {
   SkipNode<std::string> node{"MyNode", 5};

--- a/skip_list/test/ut_skip_node.hpp
+++ b/skip_list/test/ut_skip_node.hpp
@@ -5,14 +5,15 @@
 
 
 /**
- * @brief The `value` and `level` of a node should be set properly by constructor,
- * and all its forward nodes should be null.
+ * @brief The `key`-`value` pair and `level` of a node should be set properly by
+ * constructor, and all its forward nodes should be null.
  */
 TEST(SkipNodeTest, CallConstructor) {
-  SkipNode<std::string> node{"MyNode", 15};
+  SkipNode<std::string, int> node{{"MyNode", 1}, 5};
 
-  ASSERT_EQ("MyNode", node.value());
-  ASSERT_EQ(15, node.level());
+  ASSERT_EQ("MyNode", node.key());
+  ASSERT_EQ(1, node.value());
+  ASSERT_EQ(5, node.level());
   for (int i = 1; i <= node.level(); ++i) {
     ASSERT_TRUE(node.forward(i) == nullptr);
   }
@@ -21,7 +22,7 @@ TEST(SkipNodeTest, CallConstructor) {
 
 /// The forward nodes can be null.
 TEST(SkipNodeTest, SetForwardNull) {
-  SkipNode<std::string> node{"MyNode", 5};
+  SkipNode<std::string, int> node{{"MyNode", 1}, 5};
 
   ASSERT_NO_THROW(node.set_forward(nullptr, 1));
   ASSERT_TRUE(node.forward(1) == nullptr);
@@ -30,10 +31,11 @@ TEST(SkipNodeTest, SetForwardNull) {
 
 /// Forward nodes should be properly set and get when they don't exceed the forward level that the node can have.
 TEST(SkipNodeTest, SetForwardInLimit) {
-  SkipNode<std::string> node{"MyNode", 5};
-  SkipNode<std::string> forwards[] = {
-    SkipNode<std::string>{"1", 1}, SkipNode<std::string>{"2", 2}, SkipNode<std::string>{"3", 3},
-    SkipNode<std::string>{"4", 4}, SkipNode<std::string>{"5", 5}
+  SkipNode<std::string, int> node{{"MyNode", 1}, 5};
+  SkipNode<std::string, int> forwards[] = {
+    SkipNode<std::string, int>{{"a", 1}, 1}, SkipNode<std::string, int>{{"b", 2}, 2},
+    SkipNode<std::string, int>{{"c", 3}, 3}, SkipNode<std::string, int>{{"d", 4}, 4},
+    SkipNode<std::string, int>{{"e", 5}, 5},
   };
 
   for (int i = 1; i <= node.level(); ++i) {
@@ -41,15 +43,15 @@ TEST(SkipNodeTest, SetForwardInLimit) {
   }
 
   for (int i = 1; i <= node.level(); ++i) {
-    ASSERT_EQ(std::to_string(i), node.forward(i)->value());
+    ASSERT_EQ(i, node.forward(i)->value());
   }
 }
 
 
 /// Exception should be thrown when a low level node is set as a high level forward node.
 TEST(SkipNodeTest, SetForwardTooLowLevel) {
-  SkipNode<std::string> node{"MyNode", 5};
-  SkipNode<std::string> forward{"3", 3};
+  SkipNode<std::string, int> node{{"MyNode", 1}, 5};
+  SkipNode<std::string, int> forward{{"a", 1}, 3};
 
   ASSERT_THROW({
     try {
@@ -64,8 +66,8 @@ TEST(SkipNodeTest, SetForwardTooLowLevel) {
 
 /// Exception should be thrown when a level n forward node is set to a level m node, where n > m.
 TEST(SkipNodeTest, SetForwardExceedLimit) {
-  SkipNode<std::string> node{"MyNode", 5};
-  SkipNode<std::string> forward{"6", 6};
+  SkipNode<std::string, int> node{{"MyNode", 1}, 5};
+  SkipNode<std::string, int> forward{{"a", 1}, 6};
 
   ASSERT_THROW({
     try {
@@ -80,7 +82,7 @@ TEST(SkipNodeTest, SetForwardExceedLimit) {
 
 /// Exception should be thrown when getting a high level forward node from a low level node.
 TEST(SkipNodeTest, GetForwardExceedLimit) {
-  SkipNode<std::string> node{"MyNode", 5};
+  SkipNode<std::string, int> node{{"MyNode", 1}, 5};
 
   ASSERT_THROW({
     try {


### PR DESCRIPTION
Skip lists are data structures that use probabilistic balancing rather than  strictly enforced balancing.
As a result, the algorithms for insertion and deletion in skip lists are much simpler and significantly faster than equivalent algorithms for balanced trees. 

- [x] refactor duplicated searching process
- [x] support operations on (*key*, *value*) pair

## Reference
- PUGH, William. Skip lists: a probabilistic alternative to balanced trees.
Communications of the ACM, 1990, 33.6: 668-676.