### PR TITLE
AVL tree: change order of arguments & improve encapsulation 

### DIFF
--- a/avl_tree/README.md
+++ b/avl_tree/README.md
@@ -1,6 +1,6 @@
 # AVL tree
 
-AVL tree is a highly balanced binary search tree. It's height *h* is less than *1.44lgn*, where *n* is the number of elements.
+AVL tree is a highly balanced binary search tree. It's height *h* is less than *1.44lg(n)*, where *n* is the number of elements.
 
 ## Complexity
 
@@ -11,4 +11,4 @@ AVL tree is a highly balanced binary search tree. It's height *h* is less than *
 |Insert (Update) |O(*lg(n)*) |O(*lg(n)* |
 |Delete          |O(*lg(n)*) |O(*lg(n)* |
 
-When inserting, the original `TreeNode` data will be updated if key duplicates, i.e., no duplicate keys in the tree.
+When inserting, the original *value* will be updated if *key* is duplicate, which means there are no duplicate *key*s in the tree.

--- a/avl_tree/src/tree_node.hpp
+++ b/avl_tree/src/tree_node.hpp
@@ -6,18 +6,21 @@
  * allocation-deallocation counting feature, which can be used to test memory leaks.
  */
 
+ #include <algorithm>
 
-template<typename DataType, typename KeyType>
-struct TreeNode {
-  DataType data;
-  KeyType key;
-  int height = 0;
-  /* not taking ownership of any of the children */
-  TreeNode* left = nullptr;
-  TreeNode* right = nullptr;
 
-  TreeNode(const DataType& data, const KeyType& key)
-      : data(data), key(key), height(0) {
+ template<typename K /* key */, typename V /* value */>
+ struct KeyValuePair {
+   const K key;
+   V value;
+ };
+
+
+template<typename K, typename V>
+class TreeNode {
+public:
+  TreeNode(const KeyValuePair<K, V>& key_value_pair)
+      : key_{key_value_pair.key}, value_{key_value_pair.value}, height_{0} {
 #ifdef MEM_DEBUG
     ++leak_count;
 #endif
@@ -29,15 +32,62 @@ struct TreeNode {
   }
 #endif
 
-  TreeNode(const TreeNode&) = delete;
-  TreeNode& operator= (const TreeNode&) = delete;
+  K key() const {
+    return key_;
+  }
 
+  V value() const {
+    return value_;
+  }
+
+  void set_value(const V& value) {
+    value_ = value;
+  }
+
+  TreeNode<K, V>* left() const {
+    return left_;
+  }
+
+  void set_left(TreeNode<K, V>* const node) {
+    left_ = node;
+  }
+
+  TreeNode<K, V>* right() const {
+    return right_;
+  }
+
+  void set_right(TreeNode<K, V>* const node) {
+    right_ = node;
+  }
+
+  int height() const {
+    return height_;
+  }
+
+  /* If we use a recursive call to really get the height of the tree node,
+    the time complexity would be O(n). To solve this, we will have the tree
+    maintain the height of nodes, which means tree will have to adjust height
+    of all nodes affected by insertion/deletion, but still keep them O(lg(n)). */
+  void set_height(const int height) {
+    height_ = height;
+  }
+
+#ifdef MEM_DEBUG
   static int leak_count;
+#endif
+
+private:
+  const K key_;
+  V value_;
+  int height_;
+  /* not taking ownership of any of the children */
+  TreeNode<K, V>* left_ = nullptr;
+  TreeNode<K, V>* right_ = nullptr;
 };
 
 #ifdef MEM_DEBUG
-template<typename DataType, typename KeyType>
-int TreeNode<DataType, KeyType>::leak_count = 0;
+template<typename K, typename V>
+int TreeNode<K, V>::leak_count = 0;
 #endif
 
 #endif /* end of include guard: SRC_TREE_NODE_HPP_ */

--- a/avl_tree/test/ut_avl_tree.hpp
+++ b/avl_tree/test/ut_avl_tree.hpp
@@ -2,7 +2,6 @@
 
 #include <cmath>
 #include <gtest/gtest.h>
-#include <iostream>
 #include <string>
 
 #include "../src/tree_node.hpp"
@@ -11,27 +10,34 @@
 class AVLTreeTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    ASSERT_EQ(0, (TreeNode<std::string, int>::leak_count));
-    month_tree_.Insert("June", 6);
-    month_tree_.Insert("March", 3);
-    month_tree_.Insert("September", 9);
-    month_tree_.Insert("January", 1);
-    month_tree_.Insert("December", 12);
-    month_tree_.Insert("October", 10);
-    month_tree_.Insert("April", 4);
-    month_tree_.Insert("August", 8);
-    month_tree_.Insert("February", 2);
-    month_tree_.Insert("November", 11);
-    month_tree_.Insert("May", 5);
-    month_tree_.Insert("July", 7);
+#ifdef MEM_DEBUG
+    ASSERT_EQ(0, (TreeNode<int, std::string>::leak_count));
+#endif
+    month_tree_.Insert({6,  "June"});
+    month_tree_.Insert({3,  "March"});
+    month_tree_.Insert({9,  "September"});
+    month_tree_.Insert({1,  "January"});
+    month_tree_.Insert({12, "December"});
+    month_tree_.Insert({10, "October"});
+    month_tree_.Insert({4,  "April"});
+    month_tree_.Insert({8,  "August"});
+    month_tree_.Insert({2,  "February"});
+    month_tree_.Insert({11, "November"});
+    month_tree_.Insert({5,  "May"});
+    month_tree_.Insert({7,  "July"});
   }
 
-  AVLTree<std::string, int> month_tree_;
+  AVLTree<int, std::string> month_tree_;
   AVLTree<int, int> tree_;
 };
 
+
+/**
+ * Inserts a `key`-`value` with the `key` already exist, the old value
+ * should be updated by `value`.
+ */
 TEST_F(AVLTreeTest, UpdateImplicitlyByInsert) {
-  month_tree_.Insert("<October>", 10);
+  month_tree_.Insert({10, "<October>"});
 
   const std::vector<std::string> months = month_tree_.Traverse();
   ASSERT_EQ(12, months.size());
@@ -49,81 +55,125 @@ TEST_F(AVLTreeTest, UpdateImplicitlyByInsert) {
   ASSERT_EQ("December",  months.at(11));
 }
 
-TEST_F(AVLTreeTest, Search) {
-  ASSERT_EQ("January",   month_tree_.Search(1)->data);
-  ASSERT_EQ("February",  month_tree_.Search(2)->data);
-  ASSERT_EQ("March",     month_tree_.Search(3)->data);
-  ASSERT_EQ("April",     month_tree_.Search(4)->data);
-  ASSERT_EQ("May",       month_tree_.Search(5)->data);
-  ASSERT_EQ("June",      month_tree_.Search(6)->data);
-  ASSERT_EQ("July",      month_tree_.Search(7)->data);
-  ASSERT_EQ("August",    month_tree_.Search(8)->data);
-  ASSERT_EQ("September", month_tree_.Search(9)->data);
-  ASSERT_EQ("October",   month_tree_.Search(10)->data);
-  ASSERT_EQ("November",  month_tree_.Search(11)->data);
-  ASSERT_EQ("December",  month_tree_.Search(12)->data);
 
+TEST_F(AVLTreeTest, Search) {
+  ASSERT_EQ("January",   month_tree_.Search(1)->value());
+  ASSERT_EQ("February",  month_tree_.Search(2)->value());
+  ASSERT_EQ("March",     month_tree_.Search(3)->value());
+  ASSERT_EQ("April",     month_tree_.Search(4)->value());
+  ASSERT_EQ("May",       month_tree_.Search(5)->value());
+  ASSERT_EQ("June",      month_tree_.Search(6)->value());
+  ASSERT_EQ("July",      month_tree_.Search(7)->value());
+  ASSERT_EQ("August",    month_tree_.Search(8)->value());
+  ASSERT_EQ("September", month_tree_.Search(9)->value());
+  ASSERT_EQ("October",   month_tree_.Search(10)->value());
+  ASSERT_EQ("November",  month_tree_.Search(11)->value());
+  ASSERT_EQ("December",  month_tree_.Search(12)->value());
+  /* not found */
+  ASSERT_TRUE(month_tree_.Search(0) == nullptr);
   ASSERT_TRUE(month_tree_.Search(13) == nullptr);
 }
 
+
+/**
+ * Inserts 0 ~ 9, since this is the ascending order, new node is always the
+ * right-most node; left rotations should be performed correclty.
+ */
 TEST_F(AVLTreeTest, LeftRotate) {
   for (int i = 0; i < 10; ++i) {
-    tree_.Insert(i, i);
+    tree_.Insert({i, i});
   }
+
   const std::vector<int> tree_order = tree_.Traverse();
   for (int i = 0; i < 10; ++i) {
     ASSERT_EQ(i, tree_order.at(i));
   }
 }
 
+
+/**
+ * Inserts 9 ~ 0, since this is the descending order, new node is always the
+ * left-most node; right rotations should be performed correclty.
+ */
 TEST_F(AVLTreeTest, RightRotate) {
   for (int i = 9; i >= 0; --i) {
-    tree_.Insert(i, i);
+    tree_.Insert({i, i});
   }
+
   const std::vector<int> tree_order = tree_.Traverse();
   for (int i = 0; i < 10; ++i) {
     ASSERT_EQ(i, tree_order.at(i));
   }
 }
 
+
+/**
+ *    10     Produces a left-right heavy condition;
+ *    /      the order of the nodes should still be correct.
+ *   8
+ *    \
+ *     9
+ */
 TEST_F(AVLTreeTest, LeftRightRotate) {
-  tree_.Insert(10, 10);
-  tree_.Insert(8, 8);
-  tree_.Insert(9, 9);
+  tree_.Insert({10, 10});
+  tree_.Insert({8, 8});
+  tree_.Insert({9, 9});
 
   const std::vector<int> tree_order = tree_.Traverse();
   ASSERT_EQ(3, tree_order.size());
-
   ASSERT_EQ(8, tree_order.at(0));
   ASSERT_EQ(9, tree_order.at(1));
   ASSERT_EQ(10, tree_order.at(2));
 }
 
+
+/**
+ *    10     Produces a right-left heavy condition;
+ *     \     the order of the nodes should still be correct.
+ *     12
+ *    /
+ *   9
+ */
 TEST_F(AVLTreeTest, RightLeftRotate) {
-  tree_.Insert(10, 10);
-  tree_.Insert(12, 12);
-  tree_.Insert(11, 11);
+  tree_.Insert({10, 10});
+  tree_.Insert({12, 12});
+  tree_.Insert({11, 11});
 
   const std::vector<int> tree_order = tree_.Traverse();
   ASSERT_EQ(3, tree_order.size());
-
   ASSERT_EQ(10, tree_order.at(0));
   ASSERT_EQ(11, tree_order.at(1));
   ASSERT_EQ(12, tree_order.at(2));
 }
 
-TEST_F(AVLTreeTest, Height) {
-  for (int i = 0; i < 100000; ++i) {
-    tree_.Insert(i, i);
+
+/**
+ * If N elements are inserted, the height of the tree should be smaller than
+ * 1.5lg(N) (strictly 1.44 with some constants).
+ * NOTE: this is not unser worst case.
+ */
+TEST_F(AVLTreeTest, BalanceProperly) {
+  const int N = 100001;
+  /* simply divide into 2 parts, one ascending, another descending */
+  for (int i = 0; i < N / 2; ++i) {
+    tree_.Insert({i, i});
   }
+  for (int i = N - 1; i >= N / 2; --i) {
+    tree_.Insert({i, i});
+  }
+
   const std::vector<int> tree_order = tree_.Traverse();
-  for (int i = 0; i < 100000; ++i) {
+  for (int i = 0; i < N; ++i) {
     ASSERT_EQ(i, tree_order.at(i));
   }
-  // Should be 1.44, but to neglect other coefficients.
-  ASSERT_TRUE(tree_.Height() < 1.5 * log2(100000));
+  ASSERT_TRUE(tree_.height() < 1.5 * log2(N));
 }
 
+
+/**
+ * Deletes 4 months from the month tree.
+ * NOTE: target selection has not special meanings.
+ */
 TEST_F(AVLTreeTest, Delete_1) {
   month_tree_.Delete(1);
   month_tree_.Delete(4);
@@ -131,88 +181,71 @@ TEST_F(AVLTreeTest, Delete_1) {
   month_tree_.Delete(11);
 
   ASSERT_EQ(nullptr,     month_tree_.Search(1));
-  ASSERT_EQ("February",  month_tree_.Search(2)->data);
-  ASSERT_EQ("March",     month_tree_.Search(3)->data);
+  ASSERT_EQ("February",  month_tree_.Search(2)->value());
+  ASSERT_EQ("March",     month_tree_.Search(3)->value());
   ASSERT_EQ(nullptr,     month_tree_.Search(4));
-  ASSERT_EQ("May",       month_tree_.Search(5)->data);
-  ASSERT_EQ("June",      month_tree_.Search(6)->data);
+  ASSERT_EQ("May",       month_tree_.Search(5)->value());
+  ASSERT_EQ("June",      month_tree_.Search(6)->value());
   ASSERT_EQ(nullptr,     month_tree_.Search(7));
-  ASSERT_EQ("August",    month_tree_.Search(8)->data);
-  ASSERT_EQ("September", month_tree_.Search(9)->data);
-  ASSERT_EQ("October",   month_tree_.Search(10)->data);
+  ASSERT_EQ("August",    month_tree_.Search(8)->value());
+  ASSERT_EQ("September", month_tree_.Search(9)->value());
+  ASSERT_EQ("October",   month_tree_.Search(10)->value());
   ASSERT_EQ(nullptr,     month_tree_.Search(11));
-  ASSERT_EQ("December",  month_tree_.Search(12)->data);
+  ASSERT_EQ("December",  month_tree_.Search(12)->value());
 }
 
+
+/**
+ * Deletes 2 nodes from 5 nodes.
+ * NOTE: target selection has not special meanings.
+ */
 TEST_F(AVLTreeTest, Delete_2) {
-  tree_.Insert(5, 5);
-  tree_.Insert(3, 3);
-  tree_.Insert(6, 6);
-  tree_.Insert(2, 2);
-  tree_.Insert(4, 4);
+  tree_.Insert({5, 5});
+  tree_.Insert({3, 3});
+  tree_.Insert({6, 6});
+  tree_.Insert({2, 2});
+  tree_.Insert({4, 4});
 
   tree_.Delete(5);
-
-  const std::vector<int> tree_order = tree_.Traverse();
-  ASSERT_EQ(4, tree_order.size());
-
-  ASSERT_EQ(2, tree_order.at(0));
-  ASSERT_EQ(3, tree_order.at(1));
-  ASSERT_EQ(4, tree_order.at(2));
-  ASSERT_EQ(6, tree_order.at(3));
-}
-
-TEST_F(AVLTreeTest, Delete_3) {
-  tree_.Insert(5, 5);
-  tree_.Insert(3, 3);
-  tree_.Insert(6, 6);
-  tree_.Insert(2, 2);
-
-  tree_.Delete(5);
+  tree_.Delete(2);
 
   const std::vector<int> tree_order = tree_.Traverse();
   ASSERT_EQ(3, tree_order.size());
-
-  ASSERT_EQ(2, tree_order.at(0));
-  ASSERT_EQ(3, tree_order.at(1));
+  ASSERT_EQ(3, tree_order.at(0));
+  ASSERT_EQ(4, tree_order.at(1));
   ASSERT_EQ(6, tree_order.at(2));
 }
 
-TEST_F(AVLTreeTest, Delete_4) {
-  for (int i = 0; i < 100; ++i) {
-    tree_.Insert(i, i);
-  }
-  for (int i = 7; i < 100; i += 7) {
-    tree_.Delete(i);
-  }
-  const std::vector<int> tree_order = tree_.Traverse();
-  ASSERT_EQ(86, tree_order.size());
 
-  for (int prev = 0, cur = 1; cur < tree_order.size(); ++prev, ++cur) {
-    ASSERT_TRUE(tree_order.at(prev) < tree_order.at(cur));
-  }
-  // bool fail_flag = false;
-  // for (int prev = 0, cur = 1; cur < tree_order.size(); ++prev, ++cur) {
-  //   if (tree_order.at(prev) > tree_order.at(cur)) {
-  //     fail_flag = true;
-  //     std::cout << "at(" << prev << ") = " << tree_order.at(prev) << ", "
-  //               << "at(" << cur  << ") = " << tree_order.at(cur)  << '\n';
-  //   }
-  // }
-  // ASSERT_FALSE(fail_flag);
-}
-
-TEST_F(AVLTreeTest, Delete_5) {
+/** Inserts 1000 nodes and deletes all nultiple of 7. */
+TEST_F(AVLTreeTest, Delete_3) {
   for (int i = 0; i < 1000; ++i) {
-    tree_.Insert(i, i);
+    tree_.Insert({i, i});
   }
+
   for (int i = 7; i < 1000; i += 7) {
     tree_.Delete(i);
   }
+
   const std::vector<int> tree_order = tree_.Traverse();
   ASSERT_EQ(858, tree_order.size());
-
+  /* should be in ascending order */
   for (int prev = 0, cur = 1; cur < tree_order.size(); ++prev, ++cur) {
     ASSERT_TRUE(tree_order.at(prev) < tree_order.at(cur));
   }
+}
+
+
+/** Inserts 1000 nodes and deletes all of them from the tree. */
+TEST_F(AVLTreeTest, DeleteAll) {
+  for (int i = 0; i < 1000; ++i) {
+    tree_.Insert({i, i});
+  }
+
+  for (int i = 0; i < 1000; ++i) {
+    tree_.Delete(i);
+  }
+
+  ASSERT_EQ(-1 /* null root */, tree_.height());
+  ASSERT_TRUE(tree_.Traverse().empty());
 }

--- a/avl_tree/test/ut_main.cpp
+++ b/avl_tree/test/ut_main.cpp
@@ -4,8 +4,8 @@
 
 #include <gtest/gtest.h>
 
-// #include "ut_avl_tree.hpp"
 #include "ut_tree_node.hpp"
+#include "ut_avl_tree.hpp"
 
 
 int main(int argc, char **argv) {

--- a/avl_tree/test/ut_main.cpp
+++ b/avl_tree/test/ut_main.cpp
@@ -4,8 +4,9 @@
 
 #include <gtest/gtest.h>
 
-#include "ut_avl_tree.hpp"
+// #include "ut_avl_tree.hpp"
 #include "ut_tree_node.hpp"
+
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/avl_tree/test/ut_tree_node.hpp
+++ b/avl_tree/test/ut_tree_node.hpp
@@ -4,27 +4,30 @@
 #include <string>
 
 
+/** A tree node should have `key`, `value`, `height` and its `left`, `right` child. */
 TEST(TreeNodeTest, ConstructNode) {
-  TreeNode<std::string, int> tree_node("April", 4);
-  ASSERT_EQ(tree_node.data, "April");
-  ASSERT_EQ(tree_node.key, 4);
-  ASSERT_EQ(tree_node.height, 0);
-  ASSERT_TRUE(tree_node.left == nullptr);
-  ASSERT_TRUE(tree_node.right == nullptr);
+  TreeNode<int, std::string> tree_node{{4, "April"}};
+
+  ASSERT_EQ(4, tree_node.key());
+  ASSERT_EQ("April", tree_node.value());
+  ASSERT_EQ(0, tree_node.height());
+  ASSERT_TRUE(tree_node.left() == nullptr);
+  ASSERT_TRUE(tree_node.right() == nullptr);
 }
 
-TEST(TreeNodeTest, SetNode) {
-  TreeNode<std::string, int> root_node("April", 4);
-  TreeNode<std::string, int> right_node("May", 5);
-  TreeNode<std::string, int> left_node("March", 3);
-  root_node.left = &left_node;
-  root_node.right = &right_node;
 
-  ASSERT_EQ(root_node.left->data, "March");
-  ASSERT_EQ(root_node.left->key, 3);
-  ASSERT_EQ(root_node.left->height, 0);
+TEST(TreeNodeTest, SetChildren) {
+  TreeNode<int, std::string> root_node{{4, "April"}};
+  TreeNode<int, std::string> right_node{{5, "May"}};
+  TreeNode<int, std::string> left_node{{3, "March"}};
 
-  ASSERT_EQ(root_node.right->data, "May");
-  ASSERT_EQ(root_node.right->key, 5);
-  ASSERT_EQ(root_node.right->height, 0);
+  root_node.set_left(&left_node);
+  root_node.set_right(&right_node);
+
+  /* child on the both sides are set properly */
+  ASSERT_EQ("March", root_node.left()->value());
+  ASSERT_EQ(3, root_node.left()->key());
+
+  ASSERT_EQ("May", root_node.right()->value());
+  ASSERT_EQ(5, root_node.right()->key());
 }


### PR DESCRIPTION
- usually the *key* parameter is given before the *value*, so their order is changed
- encapsulation to `TreeNode`; modification through setters
- add description to methods and tests 