### PR TITLE
Add unit test CI for skip list

### DIFF
--- a/.github/workflows/skip_list.yaml
+++ b/.github/workflows/skip_list.yaml
@@ -1,0 +1,26 @@
+name: Skip List
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: unit test
+    steps:
+    - name: Install gtest manually
+      run: |
+        sudo apt-get update
+        sudo apt-get install g++
+        sudo apt-get install make
+        sudo apt-get install libgtest-dev
+        sudo apt-get install cmake
+        cd /usr/src/gtest
+        sudo cmake CMakeLists.txt
+        sudo make
+        cd lib
+        sudo cp *.a /usr/lib
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Run tests
+      working-directory: ./skip_list
+      run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 **/bin/
 **/obj/
 
-makefile
-
 # vs code
 **/.vs
 **/.vscode

--- a/skip_list/Makefile
+++ b/skip_list/Makefile
@@ -1,0 +1,19 @@
+.PHONY: dirs clean
+
+SRC = $(shell ls src/*)
+TEST = $(shell ls test/*)
+
+all: dirs bin/ut_main
+
+CXXFLAG = -Wfatal-errors
+bin/ut_main: test/ut_main.cpp $(SRC) $(TEST)
+	g++ -std=c++17 $< -o $@ -lgtest -pthread $(CXXFLAG)
+
+test: all
+	bin/ut_main
+
+dirs:
+	mkdir -p bin
+
+clean:
+	rm -f bin/*

--- a/skip_list/src/skip_list.hpp
+++ b/skip_list/src/skip_list.hpp
@@ -157,6 +157,12 @@ public:
     }
   }
 
+private:
+  SkipNode<K, V>* header_ = new SkipNode<K, V>{{K{}, V{} /* default dummy value */}, MAX_LEVEL};
+
+  /// The level of the highest level node in the list.
+  int level_count_ = 1;  /* base level starts from 1. */
+
   /**
    * @brief Generates levels randomly from level 1; level i with probability (`LEVEL_UP_PROB` ^ i).
    * i.e., a fraction `LEVEL_UP_PROB` of the nodes with level i forward nodes
@@ -209,12 +215,6 @@ public:
       std::cout << '\n';
     }
   }
-
-private:
-  SkipNode<K, V>* header_ = new SkipNode<K, V>{{K{}, V{} /* default dummy value */}, MAX_LEVEL};
-
-  /// The level of the highest level node in the list.
-  int level_count_ = 1;  /* base level starts from 1. */
 };
 
 


### PR DESCRIPTION
*Makefile* is necessary for CI yaml file to know how to compile the program, so removed from *.gitignore*.